### PR TITLE
Either exact or enum

### DIFF
--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/ConfigExtractor.scala
@@ -190,9 +190,9 @@ object ConfigExtractor {
     } yield gsaoi
   }
   // We need this available outside to calculate the GeMS parameters in ITCRequest
-  def createGsaoiParameters(filter: Gsaoi.Filter, readMode: Gsaoi.ReadMode, iq: SPSiteQuality.ImageQuality): String \/ GsaoiParameters = createGsaoiParameters(filter, readMode, iq, 0)
+  def createGsaoiParameters(filter: Gsaoi.Filter, readMode: Gsaoi.ReadMode, iq: Double \/ SPSiteQuality.ImageQuality): String \/ GsaoiParameters = createGsaoiParameters(filter, readMode, iq, 0)
 
-  def createGsaoiParameters(filter: Gsaoi.Filter, readMode: Gsaoi.ReadMode, iq: SPSiteQuality.ImageQuality, largeSkyOffset: Int): String \/ GsaoiParameters = {
+  def createGsaoiParameters(filter: Gsaoi.Filter, readMode: Gsaoi.ReadMode, iq: Double \/ SPSiteQuality.ImageQuality, largeSkyOffset: Int): String \/ GsaoiParameters = {
     import Gsaoi._
     import SPSiteQuality._
 
@@ -201,24 +201,24 @@ object ConfigExtractor {
       // pick the closest band that's supported by ITC
       List(MagnitudeBand.J, MagnitudeBand.H, MagnitudeBand.K).minBy(b => Math.abs(b.center.toNanometers - band.center.toNanometers))
 
-
     // a rudimentary approximation for the expected GeMS performance
     // http://www.gemini.edu/sciops/instruments/gems/gems-performance
     // TODO: here we should use the avg Strehl values calculated by the Mascot / AGS algorithms for better results
     def extractGems(filter: Filter): String \/ GemsParameters =
       filter.getCatalogBand.asScalaOpt.fold(error) { band =>
         (band, iq) match {
-          case (SingleBand(MagnitudeBand.J), ImageQuality.PERCENT_20) => GemsParameters(0.10, "J").right
-          case (SingleBand(MagnitudeBand.J), ImageQuality.PERCENT_70) => GemsParameters(0.05, "J").right
-          case (SingleBand(MagnitudeBand.J), ImageQuality.PERCENT_85) => GemsParameters(0.02, "J").right
-          case (SingleBand(MagnitudeBand.H), ImageQuality.PERCENT_20) => GemsParameters(0.15, "H").right
-          case (SingleBand(MagnitudeBand.H), ImageQuality.PERCENT_70) => GemsParameters(0.10, "H").right
-          case (SingleBand(MagnitudeBand.H), ImageQuality.PERCENT_85) => GemsParameters(0.05, "H").right
-          case (SingleBand(MagnitudeBand.K), ImageQuality.PERCENT_20) => GemsParameters(0.30, "K").right
-          case (SingleBand(MagnitudeBand.K), ImageQuality.PERCENT_70) => GemsParameters(0.15, "K").right
-          case (SingleBand(MagnitudeBand.K), ImageQuality.PERCENT_85) => GemsParameters(0.10, "K").right
-          case (_, ImageQuality.ANY)             => "GeMS cannot be used in IQ=Any conditions".left
-          case _                                 => "ITC GeMS only supports J, H and K band".left
+          case (_, -\/(_)) => "GeMS requires a predefined image quality setting".left // TODO: what should actually happen here?
+          case (SingleBand(MagnitudeBand.J), \/-(ImageQuality.PERCENT_20)) => GemsParameters(0.10, "J").right
+          case (SingleBand(MagnitudeBand.J), \/-(ImageQuality.PERCENT_70)) => GemsParameters(0.05, "J").right
+          case (SingleBand(MagnitudeBand.J), \/-(ImageQuality.PERCENT_85)) => GemsParameters(0.02, "J").right
+          case (SingleBand(MagnitudeBand.H), \/-(ImageQuality.PERCENT_20)) => GemsParameters(0.15, "H").right
+          case (SingleBand(MagnitudeBand.H), \/-(ImageQuality.PERCENT_70)) => GemsParameters(0.10, "H").right
+          case (SingleBand(MagnitudeBand.H), \/-(ImageQuality.PERCENT_85)) => GemsParameters(0.05, "H").right
+          case (SingleBand(MagnitudeBand.K), \/-(ImageQuality.PERCENT_20)) => GemsParameters(0.30, "K").right
+          case (SingleBand(MagnitudeBand.K), \/-(ImageQuality.PERCENT_70)) => GemsParameters(0.15, "K").right
+          case (SingleBand(MagnitudeBand.K), \/-(ImageQuality.PERCENT_85)) => GemsParameters(0.10, "K").right
+          case (_, \/-(ImageQuality.ANY))             => "GeMS cannot be used in IQ=Any conditions".left
+          case _                                      => "ITC GeMS only supports J, H and K band".left
         }
     }
 

--- a/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
+++ b/bundle/edu.gemini.itc.shared/src/main/scala/edu/gemini/itc/shared/Parameters.scala
@@ -1,18 +1,29 @@
 package edu.gemini.itc.shared
 
-import edu.gemini.spModel.core.{SpectralDistribution, UniformSource, SpatialProfile, Redshift, BrightnessUnit, MagnitudeBand}
-import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.{WaterVapor, CloudCover, SkyBackground, ImageQuality}
+import edu.gemini.shared.util.immutable.ImEither
+import edu.gemini.spModel.core.{BrightnessUnit, MagnitudeBand, Redshift, SpatialProfile, SpectralDistribution, UniformSource}
+import edu.gemini.spModel.gemini.obscomp.SPSiteQuality.{CloudCover, ImageQuality, SkyBackground, WaterVapor}
+
+import scalaz.\/
 
 // ==== Observing conditions
 
 final case class ObservingConditions(
-                      iq: ImageQuality,
-                      cc: CloudCover,
+                      iq: Double \/ ImageQuality,
+                      cc: Double \/ CloudCover,
                       wv: WaterVapor,
                       sb: SkyBackground,
-                      airmass: Double,
-                      exactiq: Double,
-                      exactcc: Double)
+                      airmass: Double) {
+
+  import edu.gemini.shared.util.immutable.ScalaConverters._
+
+  def javaIq: ImEither[java.lang.Double, ImageQuality] =
+    iq.leftMap(d => new java.lang.Double(d.doubleValue())).asImEither
+
+  def javaCc: ImEither[java.lang.Double, CloudCover] =
+    cc.leftMap(d => new java.lang.Double(d.doubleValue())).asImEither
+
+}
 
 // ==== Source definition
 final case class SourceDefinition(

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/SEDFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/base/SEDFactory.java
@@ -252,7 +252,7 @@ public final class SEDFactory {
         // inputs: SED, AIRMASS, sky emmision file, mirror configuration,
         // output: SED and sky background as they arrive at instruments
 
-        final SampledSpectrumVisitor clouds = CloudTransmissionVisitor.create(odp.cc(), odp.exactcc());
+        final SampledSpectrumVisitor clouds = CloudTransmissionVisitor.create(odp.javaCc());
         sed.accept(clouds);
 
         final SampledSpectrumVisitor water = WaterTransmissionVisitor.create(

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/CloudTransmissionVisitor.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/CloudTransmissionVisitor.java
@@ -3,6 +3,7 @@ package edu.gemini.itc.operation;
 import edu.gemini.itc.base.DefaultArraySpectrum;
 import edu.gemini.itc.base.ITCConstants;
 import edu.gemini.itc.base.TransmissionElement;
+import edu.gemini.shared.util.immutable.ImEither;
 import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import java.util.logging.Logger;
 
@@ -20,10 +21,8 @@ public final class CloudTransmissionVisitor {
     /**
      * Constructs transmission visitor for clouds.
      */
-    public static TransmissionElement create(final SPSiteQuality.CloudCover cc, double exactcc) {
-
-        if (cc == SPSiteQuality.CloudCover.EXACT) {
-
+    public static TransmissionElement create(final ImEither<Double, SPSiteQuality.CloudCover> cc) {
+        return cc.biFold(exactcc -> {
             if (exactcc < 0.0) throw new IllegalArgumentException("Exact Cloud Cover must be >= zero magnitudes.");
             final double[][] data = new double[2][2];
             data[0][0] = 300.0;                      // x = wavelength
@@ -34,11 +33,7 @@ public final class CloudTransmissionVisitor {
             final TransmissionElement te;
             te = new TransmissionElement(new DefaultArraySpectrum(data));
             return te;
-
-        } else {
-
-            return new TransmissionElement(ITCConstants.TRANSMISSION_LIB + "/" + FILENAME +
-                    "_" + cc.sequenceValue() + ITCConstants.DATA_SUFFIX);
-        }
+        }, ccEnum -> new TransmissionElement(ITCConstants.TRANSMISSION_LIB + "/" + FILENAME +
+                "_" + ccEnum.sequenceValue() + ITCConstants.DATA_SUFFIX));
     }
 }

--- a/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImageQualityCalculationFactory.java
+++ b/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/operation/ImageQualityCalculationFactory.java
@@ -4,7 +4,6 @@ import edu.gemini.itc.base.Instrument;
 import edu.gemini.itc.shared.ObservingConditions;
 import edu.gemini.itc.shared.SourceDefinition;
 import edu.gemini.itc.shared.TelescopeDetails;
-import edu.gemini.spModel.gemini.obscomp.SPSiteQuality;
 import edu.gemini.spModel.guide.GuideProbe;
 import edu.gemini.spModel.core.GaussianSource;
 
@@ -19,9 +18,9 @@ public final class ImageQualityCalculationFactory {
             TelescopeDetails telescope,
             Instrument instrument) {
 
-        if (observingConditions.iq() == SPSiteQuality.ImageQuality.EXACT) {
+        if (observingConditions.javaIq().isLeft()) {
             // Case C: The exact delivered FHWM at the science wavelength is specified.
-            final double fwhm = observingConditions.exactiq();
+            final double fwhm = observingConditions.javaIq().toOptionLeft().getValue();
             if (fwhm <= 0.0) throw new IllegalArgumentException("Exact Image Quality must be > zero arcseconds.");
             return new GaussianImageQualityCalculation(fwhm);
 
@@ -42,7 +41,7 @@ public final class ImageQualityCalculationFactory {
             // This case creates an ImageQuality Calculation
             return new ImageQualityCalculation(
                     wfs,
-                    observingConditions.iq(),
+                    observingConditions.javaIq().toOption().getValue(),
                     observingConditions.airmass(),
                     instrument.getEffectiveWavelength());
         }

--- a/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPSiteQuality.java
+++ b/bundle/edu.gemini.pot/src/main/java/edu/gemini/spModel/gemini/obscomp/SPSiteQuality.java
@@ -303,8 +303,7 @@ public class SPSiteQuality extends AbstractDataObject implements PropertyProvide
         PERCENT_90("90%",        90, -3.0) {
             @Override public boolean isObsolete() { return true; }
         },
-        ANY(       "Any",       100, -3.0),
-        EXACT(     "Exact",       0,  0.0);
+        ANY(       "Any",       100, -3.0);
 
         /** The default CloudCover value **/
         public static CloudCover DEFAULT = ANY;
@@ -365,8 +364,7 @@ public class SPSiteQuality extends AbstractDataObject implements PropertyProvide
         PERCENT_20("20%/Best",  20,  0.5),
         PERCENT_70("70%/Good",  70,  0.0),
         PERCENT_85("85%/Poor",  85, -0.5),
-        ANY(       "Any",      100, -1.0),
-        EXACT(     "Exact",      0,  0.0);
+        ANY(       "Any",      100, -1.0);
 
         /** The default ImageQuality value **/
         public static ImageQuality DEFAULT = ANY;

--- a/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/itc/ConditionsPanel.scala
+++ b/bundle/jsky.app.ot/src/main/scala/jsky/app/ot/itc/ConditionsPanel.scala
@@ -58,15 +58,16 @@ final class ConditionsPanel(owner: EdIteratorFolder) extends GridBagPanel {
   private val wv = new ConditionCB[WaterVapor]     (WaterVapor.values,                          "WV " + _.displayValue())
   private val am = new ConditionCB[Double]         (List(1.0, 1.5, 2.0),                        d => f"Airmass $d%.1f")
 
-  def conditions = new ObservingConditions(
-    iq.selection.item,
-    cc.selection.item,
-    wv.selection.item,
-    sb.selection.item,
-    am.selection.item, 0.0, 0.0
-  )
+  def conditions: ObservingConditions =
+    ObservingConditions(
+      \/-(iq.selection.item),
+      \/-(cc.selection.item),
+      wv.selection.item,
+      sb.selection.item,
+      am.selection.item
+    )
 
-  def update() = {
+  def update(): Unit =
     // Note: site quality node can be missing (i.e. null)
     Option(owner.getContextSiteQuality).foreach { qual =>
       sb.sync(qual.getSkyBackground)
@@ -77,7 +78,6 @@ final class ConditionsPanel(owner: EdIteratorFolder) extends GridBagPanel {
       // TODO: can we get this value from the airmass constraints?
       am.sync(1.5)
     }
-  }
 
   tooltip = ttMsg
 


### PR DESCRIPTION
This develops the idea we discussed a bit to make IQ and CC be either an exact value or else the enum.  It doesn't, um, compile yet because there are cases where we simply assume that we're getting the enum in the recipes and I wasn't sure what to do with them.

You can "fix" these by again assuming that it is the `enum` and letting it blow up if it is given an exact value.  For example

```java
   _obsConditionParameters.javaCc().getOption().getValue().getExtinction()
```

in the first error below instead of `_obsConditionParameters.cc().getExtinction()`.  This is probably not a good idea though since it leaves the exactly specified value unhandled.

```
> compile
[info] Compiling 3 Scala sources and 32 Java sources to /Users/swalker/dev/ocs/bundle/edu.gemini.itc/target/scala-2.11/classes...
[error] /Users/swalker/dev/ocs/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java:93: cannot find symbol
[error]   symbol:   method getExtinction()
[error]   location: class scalaz.$bslash$div<java.lang.Object,edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover>
[error]             final Altair ao = new Altair(instrument.getEffectiveWavelength(), _telescope.getTelescopeDiameter(), IQcalc.getImageQuality(), _obsConditionParameters.cc().getExtinction(), _gnirsParameters.altair().get(), 0.1);
[error] /Users/swalker/dev/ocs/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gnirs/GnirsRecipe.java:329: cannot find symbol
[error]   symbol:   method getExtinction()
[error]   location: class scalaz.$bslash$div<java.lang.Object,edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover>
[error]             final Altair ao = new Altair(instrument.getEffectiveWavelength(), _telescope.getTelescopeDiameter(), IQcalc.getImageQuality(), _obsConditionParameters.cc().getExtinction(), _gnirsParameters.altair().get(), 0.1); // Since GNIRS does not have perfect optics, the PSF delivered by Altair is convolved with a ~0.10" Gaussian to reproduce the ~0.12" images which are measured under optimal conditions.
[error] /Users/swalker/dev/ocs/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/gsaoi/GsaoiRecipe.java:61:  scalaz.$bslash$div<java.lang.Object,edu.gemini.spModel.gemini.obscomp.SPSiteQuality.ImageQuality> cannot be converted to edu.gemini.spModel.gemini.obscomp.SPSiteQuality.ImageQuality
[error]                 _obsConditionParameters.iq(),
[error] /Users/swalker/dev/ocs/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/nifs/NifsRecipe.java:70: cannot find symbol
[error]   symbol:   method getExtinction()
[error]   location: class scalaz.$bslash$div<java.lang.Object,edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover>
[error]             final Altair ao = new Altair(instrument.getEffectiveWavelength(), _telescope.getTelescopeDiameter(), IQcalc.getImageQuality(), _obsConditionParameters.cc().getExtinction(), _nifsParameters.altair().get(), 0.0);
[error] /Users/swalker/dev/ocs/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java:82: cannot find symbol
[error]   symbol:   method getExtinction()
[error]   location: class scalaz.$bslash$div<java.lang.Object,edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover>
[error]             final Altair ao = new Altair(instrument.getEffectiveWavelength(), _telescope.getTelescopeDiameter(), IQcalc.getImageQuality(), _obsConditionParameters.cc().getExtinction(), niriParameters.altair().get(), 0.0);
[error] /Users/swalker/dev/ocs/bundle/edu.gemini.itc/src/main/java/edu/gemini/itc/niri/NiriRecipe.java:149: cannot find symbol
[error]   symbol:   method getExtinction()
[error]   location: class scalaz.$bslash$div<java.lang.Object,edu.gemini.spModel.gemini.obscomp.SPSiteQuality.CloudCover>
[error]             final Altair ao = new Altair(instrument.getEffectiveWavelength(), _telescope.getTelescopeDiameter(), IQcalc.getImageQuality(), _obsConditionParameters.cc().getExtinction(), niriParameters.altair().get(), 0.0);
[info] Some messages have been simplified; recompile with -Xdiags:verbose to get full output
[error] (bundle_edu_gemini_itc/compile:compileIncremental) javac returned nonzero exit code
[error] Total time: 10 s, completed Aug 24, 2021 5:42:09 PM
> 
```